### PR TITLE
refactor: prompt system with schema and processing modes

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -25,6 +25,9 @@ class Config:
         self.llm_timeout = self._get_config_value("llm", "timeout", 60)
         self.llm_max_workers = self._get_config_value("llm", "max_workers", 4)
         self.llm_RPM = self._get_config_value("llm", "RPM", 1000)
+        self.llm_prompt_processing = self._get_config_value(
+            "llm", "prompt_processing", "strict"
+        )
 
         self.digest_name = self._get_config_value(
             "digest", "name", "֎Minifluxᴬᴵ Digest for you"

--- a/config.sample.Chinese.yml
+++ b/config.sample.Chinese.yml
@@ -16,6 +16,10 @@ llm:
   # timeout: 60        # 请求超时时间，单位秒 (默认: 60)
   # max_workers: 4     # 并发请求数限制 (默认: 4)
   # RPM: 15            # 每分钟请求数限制 (默认: 1000)
+  # prompt_processing: strict  # none | strict（默认）| single
+  #   none:   原样透传多条消息，适用于 OpenAI 等多 system 消息的模型
+  #   strict: 合并同角色消息，非首条 system 降级为 <instruction>，适用于 DeepSeek 等
+  #   single: 全部合并为单条 user 消息，适用于不支持 system 角色的模型
 
 digest:
   # RSS 订阅源生成的服务地址 (Docker Compose 环境使用容器名)

--- a/config.sample.English.yml
+++ b/config.sample.English.yml
@@ -16,6 +16,10 @@ llm:
   # timeout: 60        # Request timeout in seconds (default: 60)
   # max_workers: 4     # Concurrent request limit (default: 4)
   # RPM: 15            # Requests per minute limit (default: 1000)
+  # prompt_processing: strict  # none | strict (default) | single
+  #   none:   Pass-through multiple messages as-is, for OpenAI and models supporting multiple system messages
+  #   strict: Merge same-role messages, demote non-first system to <instruction>, for DeepSeek etc.
+  #   single: Collapse all into a single user message, for models without system role support
 
 digest:
   # Service URL for RSS feed generation (use container name for Docker Compose)

--- a/core/digest_generator.py
+++ b/core/digest_generator.py
@@ -7,25 +7,10 @@ from typing import Any
 from common import DIGEST_FILE, SUMMARY_FILE, SUMMARY_FILE_LOCK, config
 from common.logger import get_logger
 
-from core.llm_client import get_completion
+from core.llm_client import chat_completion
+from core.prompt_schema import DIGEST_PROMPT_SCHEMA
 
 logger = get_logger(__name__)
-
-# Input ID prefix
-INPUT_FORMAT_PROMPT = """\
-<input_format>
-Each entry is prefixed with its unique ID: [^ID].
-For example: [^175799] Summary text.
-</input_format>"""
-
-# Citation via [^ID]
-CITATION_PROMPT = """\
-<citation>
-Always use [^ID] format for citations. Chain multiple sources without spaces: [^123][^456].
-Unless otherwise specified, append [^ID] directly after the relevant key point.
-
-Verify: before writing, check every [^ID] in your draft against the input.
-</citation>"""
 
 
 def generate_digest_content() -> str | None:
@@ -62,26 +47,18 @@ def _generate_greeting() -> str:
 
     Returns:
         Generated greeting string
-
-    Raises:
-        Exception: If both attempts fail
     """
     current_time = time.strftime("%B %d, %Y at %I:%M %p")
     logger.debug(f"Generating greeting for time: {current_time}")
 
-    try:
-        return get_completion(
-            config.digest_prompts["greeting"],
-            f"Current time: {current_time}",
-            temperature=0.8,
-        )
-    except Exception as e:
-        logger.warning(f"Failed to generate greeting, retrying once: {e}")
-        return get_completion(
-            config.digest_prompts["greeting"],
-            f"Current time: {current_time}",
-            temperature=0.8,
-        )
+    return chat_completion(
+        [
+            ("system", config.digest_prompts["greeting"]),
+            ("user", f"Current time: {current_time}"),
+        ],
+        temperature=0.8,
+        retries=1,
+    )
 
 
 def _generate_summary(summaries: list[dict[str, Any]]) -> str:
@@ -93,24 +70,22 @@ def _generate_summary(summaries: list[dict[str, Any]]) -> str:
 
     Returns:
         Generated summary content string with entry links
-
-    Raises:
-        Exception: If both attempts fail
     """
     logger.debug("Generating digest content from summaries")
     contents = "\n\n".join(f"[^{s['id']}] {s['content']}" for s in summaries)
 
-    system_prompts = [INPUT_FORMAT_PROMPT, CITATION_PROMPT]
+    prompts = [
+        ("system", DIGEST_PROMPT_SCHEMA.input_format),
+        ("system", DIGEST_PROMPT_SCHEMA.citation_format),
+        ("system", DIGEST_PROMPT_SCHEMA.citation_verification),
+    ]
 
     config_prompt = (config.digest_prompts or {}).get("summary", "")
     if config_prompt:
-        system_prompts.append(config_prompt)
+        prompts.append(("system", config_prompt))
+    prompts.append(("user", contents))
 
-    try:
-        summary = get_completion(system_prompts, contents)
-    except Exception as e:
-        logger.warning(f"Failed to generate summary, retrying once: {e}")
-        summary = get_completion(system_prompts, contents)
+    summary = chat_completion(prompts, retries=1)
 
     if config.digest_entry_url:
         summary = _apply_entry_links(summary, config.digest_entry_url)

--- a/core/entry_processor.py
+++ b/core/entry_processor.py
@@ -15,31 +15,12 @@ from core.content_helper import (
     to_markdown,
 )
 from core.digest_generator import save_summary
-from core.llm_client import get_completion
+from core.llm_client import chat_completion
 from core.miniflux_client import get_miniflux_client
 from core.rule_matcher import match_rules
+from core.prompt_schema import ENTRY_PROMPT_SCHEMA
 
 logger = get_logger(__name__)
-
-# Input format description — tells the LLM about the data structure
-AGENT_INPUT_FORMAT = """\
-<input_format>
-The input provides <title> and <content>.
-The <title> is for context only.
-The <content> is the data to process according to the instructions.
-</input_format>"""
-
-# Data template — wraps title/content with semantic XML tags
-ENTRY_TEMPLATE = """\
-<entry>
-<title>
-{title}
-</title>
-
-<content>
-{content}
-</content>
-</entry>"""
 
 # Entry processing cache to avoid duplicate processing
 _ENTRY_CACHE_LOCK = threading.Lock()
@@ -228,18 +209,20 @@ def _get_agent_content(agent_name: str, agent: Agent, entry: dict[str, Any]) -> 
     title = entry["title"]
     content_markdown = to_markdown(entry["content"])
 
-    system_prompts = [AGENT_INPUT_FORMAT, agent.prompt]
-    user_prompt = ENTRY_TEMPLATE.replace("{title}", title).replace(
-        "{content}", content_markdown
-    )
+    user_prompt = ENTRY_PROMPT_SCHEMA.render(title=title, content=content_markdown)
+    prompts = [
+        ("system", ENTRY_PROMPT_SCHEMA.format_description),
+        ("system", agent.prompt),
+        ("user", user_prompt),
+    ]
 
     logger.debug_entry(
         entry,
         agent_name=agent_name,
-        message=f"LLM request sent: system_prompts={system_prompts}; user_prompt={user_prompt}",
+        message=f"LLM request sent: prompts={prompts}",
     )
 
-    agent_content = get_completion(system_prompts, user_prompt)
+    agent_content = chat_completion(prompts)
 
     logger.debug_entry(
         entry, agent_name=agent_name, message=f"LLM response received: {agent_content}"

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -1,62 +1,52 @@
 from common import config
 from common.exceptions import LLMResponseError
 from common.logger import get_logger
+from core.prompt_schema import apply_prompt_processing
 from openai import OpenAI
 from ratelimit import limits, sleep_and_retry
 
 logger = get_logger(__name__)
-
-DEFAULT_SYSTEM_PROMPT = (
-    "You are Miniflux AI Agent, skillfully interpreting RSS content "
-    "to reframe its message with clarity and depth as requested."
-)
 
 llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key)
 
 
 @sleep_and_retry
 @limits(calls=config.llm_RPM, period=60)
-def get_completion(
-    system_prompt: str | list[str], user_prompt: str, temperature: float | None = None
+def chat_completion(
+    prompts: list[tuple[str, str]], temperature: float | None = None, retries: int = 0
 ) -> str:
-    """
-    Get completion from LLM
+    for attempt in range(retries + 1):
+        try:
+            kwargs = {
+                "model": config.llm_model,
+                "timeout": config.llm_timeout,
+                "messages": apply_prompt_processing(
+                    prompts, config.llm_prompt_processing
+                ),
+            }
 
-    Args:
-        system_prompt: System prompt(s) for the LLM (if empty, uses default)
-        user_prompt: User prompt for the LLM
-        temperature: Controls randomness (0.0-2.0). Higher = more creative
+            if temperature is not None:
+                kwargs["temperature"] = temperature
 
-    Returns:
-        LLM response content
+            completion = llm_client.chat.completions.create(**kwargs)
+            logger.debug(f"LLM response: {completion}")
 
-    Raises:
-        ValueError: If LLM returns empty or invalid response
-        Exception: If LLM API call fails
-    """
-    prompts = [system_prompt] if isinstance(system_prompt, str) else system_prompt
-    prompts = [p for p in prompts if p and p.strip()] or [DEFAULT_SYSTEM_PROMPT]
+            if not completion.choices or not completion.choices[0].message:
+                raise LLMResponseError(
+                    f"LLM returned unexpected response: {completion}"
+                )
 
-    messages = [{"role": "system", "content": p} for p in prompts]
-    messages.append({"role": "user", "content": user_prompt})
+            content = completion.choices[0].message.content
+            if not content:
+                raise LLMResponseError(f"LLM returned empty content: {completion}")
 
-    kwargs = {
-        "model": config.llm_model,
-        "messages": messages,
-        "timeout": config.llm_timeout,
-    }
-
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-
-    completion = llm_client.chat.completions.create(**kwargs)
-    logger.debug(f"LLM response: {completion}")
-
-    if not completion.choices or not completion.choices[0].message:
-        raise LLMResponseError(f"LLM returned unexpected response: {completion}")
-
-    content = completion.choices[0].message.content
-    if not content:
-        raise LLMResponseError(f"LLM returned empty content: {completion}")
-
-    return content.strip()
+            return content.strip()
+        except Exception:
+            if attempt < retries:
+                logger.warning(
+                    "Chat completion failed, retrying (%d/%d)...",
+                    attempt + 1,
+                    retries,
+                )
+                continue
+            raise

--- a/core/prompt_schema.py
+++ b/core/prompt_schema.py
@@ -1,0 +1,104 @@
+"""Prompt schema definitions — format descriptions, templates, and message processing."""
+
+from dataclasses import dataclass
+from string import Template
+
+
+@dataclass(frozen=True)
+class EntryPromptSchema:
+    """Agent entry schema — format description and template are a coupled pair.
+
+    The format_description tells the LLM about the data structure,
+    while template renders the actual data. They must stay in sync.
+    """
+
+    format_description: str = (
+        "<input_format>\n"
+        "The input provides <title> and <content>.\n"
+        "The <title> is for context only.\n"
+        "The <content> is the data to process according to the instructions.\n"
+        "</input_format>"
+    )
+    template: str = (
+        "<entry>\n"
+        "<title>\n"
+        "$title\n"
+        "</title>\n"
+        "\n"
+        "<content>\n"
+        "$content\n"
+        "</content>\n"
+        "</entry>"
+    )
+
+    def render(self, title: str, content: str) -> str:
+        """Render the entry template with the given title and content."""
+        return Template(self.template).safe_substitute(title=title, content=content)
+
+
+ENTRY_PROMPT_SCHEMA = EntryPromptSchema()
+
+
+@dataclass(frozen=True)
+class DigestPromptSchema:
+    """Digest prompt schema — format descriptions for digest generation.
+
+    These describe the data format and citation rules to the LLM.
+    The user-configurable prompts (greeting, summary) live in YAML config.
+    """
+
+    input_format: str = (
+        # [^ID] is concise — entries are referenced by ID multiple times
+        # throughout a digest, so compact notation saves meaningful tokens.
+        "<input_format>\n"
+        "Each entry is prefixed with its unique ID: [^ID].\n"
+        "For example: [^175799] Summary text.\n"
+        "</input_format>"
+    )
+    citation_format: str = (
+        "<citation_format>\n"
+        "Always use [^ID] format for citations. "
+        "Chain multiple sources without spaces: [^123][^456].\n"
+        "Unless otherwise specified, append [^ID] directly after the relevant key point.\n"
+        "</citation_format>"
+    )
+    citation_verification: str = (
+        "<citation_verification>\n"
+        "Before writing: check every [^ID] in your draft against the input.\n"
+        "After writing: verify each [^ID] exists in the source data.\n"
+        "</citation_verification>"
+    )
+
+
+DIGEST_PROMPT_SCHEMA = DigestPromptSchema()
+
+
+def apply_prompt_processing(
+    prompts: list[tuple[str, str]], mode: str
+) -> list[dict[str, str]]:
+    """Transform ordered prompt tuples into API messages per processing mode."""
+    if mode == "none":
+        return [{"role": r, "content": c} for r, c in prompts]
+    if mode == "strict":
+        # 1. merge consecutive same-role prompts
+        merged: list[dict[str, str]] = []
+        for role, content in prompts:
+            if merged and merged[-1]["role"] == role:
+                merged[-1]["content"] += "\n\n" + content
+            else:
+                merged.append({"role": role, "content": content})
+        # 2. non-first system → user, wrapped in <instruction> to preserve weight
+        for m in merged[1:]:
+            if m["role"] == "system":
+                m["role"] = "user"
+                m["content"] = f"<instruction>\n{m['content']}\n</instruction>"
+        # 3. re-merge consecutive same-role after demotion
+        result: list[dict[str, str]] = []
+        for m in merged:
+            if result and result[-1]["role"] == m["role"]:
+                result[-1]["content"] += "\n\n" + m["content"]
+            else:
+                result.append(m)
+        return result
+    if mode == "single":
+        return [{"role": "user", "content": "\n\n".join(c for _, c in prompts)}]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,22 @@ agents: {}
         self.assertEqual(config.llm_timeout, 60)  # Default
         self.assertEqual(config.llm_max_workers, 4)  # Default
         self.assertEqual(config.llm_RPM, 1000)  # Default
+        self.assertEqual(config.llm_prompt_processing, "strict")  # Default
+
+    def test_load_prompt_processing_explicit(self):
+        """Test explicit prompt_processing config values"""
+        for mode in ("none", "strict", "single"):
+            with self.subTest(mode=mode):
+                config_content = f"""
+miniflux:
+  base_url: http://miniflux.local
+llm:
+  base_url: http://llm.local
+  prompt_processing: {mode}
+agents: {{}}
+"""
+                config = self._create_config(config_content)
+                self.assertEqual(config.llm_prompt_processing, mode)
 
     def test_load_agents_basic(self):
         """Test loading basic agent configuration"""


### PR DESCRIPTION
- Extract core/prompt_schema.py with EntryPromptSchema and DigestPromptSchema, binding format description with template
- Add llm_prompt_processing config option (default: strict)
  - none: pass-through, for multi-system-message models (OpenAI)
  - strict: merge same-role, demote extras to <instruction> (DeepSeek)
  - single: collapse to one user message (no system role models)